### PR TITLE
Listen on all interfaces

### DIFF
--- a/Voice/Answering Machine Detection with Ruby/app.rb
+++ b/Voice/Answering Machine Detection with Ruby/app.rb
@@ -3,6 +3,11 @@ require 'sinatra'
 require 'signalwire'
 
 set :port, 8080
+set :bind, '0.0.0.0'
+
+get '/' do
+  "It's working!"
+end
 
 post '/start' do
   response = Signalwire::Sdk::VoiceResponse.new


### PR DESCRIPTION
In order for the Sinatra server running inside the docker container to be available outside the container (either on my local machine or trying to tunnel to it), I needed to add this setting. Without it, I was not able to get a successful connection.